### PR TITLE
Reload search table for no data

### DIFF
--- a/Longboxed-iOS/Controllers/Navigation/Search/LBXSearchTableViewController.m
+++ b/Longboxed-iOS/Controllers/Navigation/Search/LBXSearchTableViewController.m
@@ -39,6 +39,10 @@
 
 - (void)updateSearchResultsForSearchController:(UISearchController *)searchController
 {
+    
+    if(searchController.searchBar.text.length == 0){
+        [self.tableView reloadData];
+    }
 
 //    if (searchController.searchBar.text.length) {
 //        [[UIBarButtonItem appearanceWhenContainedIn: [UISearchBar class], nil] setTintColor:[UIColor blackColor]];


### PR DESCRIPTION
This will reload the search table when there's no data. Added to fix a crash: search for keyword, cancel search bar, activate search again and enter any keyword; table appears with search results of old keyword and selecting any index causes the app to crash.

This should cover Cancel, Backspace and Cross in textfield as positive search results are already handled in the Dashboard and PullList controllers :)